### PR TITLE
FAI-3413 Funding Projection Tool Survey - Banner (Employer account)

### DIFF
--- a/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateApplicationContent.sql
+++ b/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateApplicationContent.sql
@@ -24,6 +24,7 @@ INSERT #ApplicationContent VALUES (8, 2, 1)
 INSERT #ApplicationContent VALUES (9, 2, 2)
 INSERT #ApplicationContent VALUES (10, 8, 1)
 INSERT #ApplicationContent VALUES (11, 8, 2)
+INSERT #ApplicationContent VALUES (12, 9, 5)
 
 SET IDENTITY_INSERT [dbo].[ApplicationContent] ON 
 

--- a/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateContent.sql
+++ b/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateContent.sql
@@ -82,6 +82,16 @@ INSERT #Content VALUES (8, 1, '<div class="govuk-notification-banner" role="regi
     </div>
 </div>', NULL, NULL, 0)
 
+INSERT #Content VALUES (9, 1, '<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Help improve the planning of your levy spend</p>
+        <p class="govuk-body">Tell us what you think by <a href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_07lXN4zCMS6ZvyS" target="_blank" class="govuk-link">completing our survey</a>.</p>
+    </div>
+</div>', '2026-05-26', NULL, 1)
+
 
 SET IDENTITY_INSERT [dbo].[Content] ON 
 

--- a/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateContent.sql
+++ b/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateContent.sql
@@ -88,7 +88,7 @@ INSERT #Content VALUES (9, 1, '<div class="govuk-notification-banner" role="regi
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Help improve the planning of your levy spend</p>
-        <p class="govuk-body">Tell us what you think by <a href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_07lXN4zCMS6ZvyS" target="_blank" class="govuk-link">completing a short survey.</a></p>
+        <p class="govuk-body">Tell us what you think by <a href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_07lXN4zCMS6ZvyS" target="_blank" class="govuk-link govuk-link--no-visited-state">completing a short survey (opens in new tab).</a></p>
     </div>
 </div>', '2026-05-26', NULL, 1)
 

--- a/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateContent.sql
+++ b/src/SFA.DAS.ContentApi.Database/Scripts/PostDeployment/InsertOrUpdateContent.sql
@@ -88,7 +88,7 @@ INSERT #Content VALUES (9, 1, '<div class="govuk-notification-banner" role="regi
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Help improve the planning of your levy spend</p>
-        <p class="govuk-body">Tell us what you think by <a href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_07lXN4zCMS6ZvyS" target="_blank" class="govuk-link">completing our survey</a>.</p>
+        <p class="govuk-body">Tell us what you think by <a href="https://dferesearch.fra1.qualtrics.com/jfe/form/SV_07lXN4zCMS6ZvyS" target="_blank" class="govuk-link">completing a short survey.</a></p>
     </div>
 </div>', '2026-05-26', NULL, 1)
 


### PR DESCRIPTION
feat: add new application and content entries

Added a new entry to the `#ApplicationContent` temporary table in `InsertOrUpdateApplicationContent.sql` with values `(12, 9, 5)` to insert a new application content record.

Added a new entry to the `#Content` temporary table in `InsertOrUpdateContent.sql` with values `(9, 1, ...)`, including an HTML structure for a "govuk-notification-banner" encouraging users to complete a survey. Metadata such as a date (`2026-05-26`) and a flag value (`1`) were also included.

Both changes involve enabling `IDENTITY_INSERT` and using `MERGE` statements to synchronize temporary table data with the target tables.